### PR TITLE
#18 point detail store

### DIFF
--- a/src/main/java/com/backend/backend/domain/pointDetail/PointDetail.java
+++ b/src/main/java/com/backend/backend/domain/pointDetail/PointDetail.java
@@ -1,7 +1,6 @@
 package com.backend.backend.domain.pointDetail;
 
 import com.backend.backend.domain.member.Member;
-import com.backend.backend.domain.transactionDetail.TransactionStatus;
 import com.backend.backend.exception.NotExistException;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -45,11 +44,11 @@ public class PointDetail {
     @Enumerated(EnumType.STRING)
     private PointStatus status;
 
-    private String detail;
+    private String memo;
 
     @Builder
     public PointDetail(Member owner, String recipient, String sender,
-                       PointStatus status,Long amount, String detail) {
+                       PointStatus status,Long amount, String memo) {
         Assert.hasText(recipient, "수신처가 없습니다");
         Assert.hasText(sender, "발신처가 없습니다");
         if(owner==null){
@@ -67,6 +66,6 @@ public class PointDetail {
         this.sender = sender;
         this.status = status;
         this.amount = amount;
-        this.detail = detail;
+        this.memo = memo;
     }
 }

--- a/src/main/java/com/backend/backend/domain/pointDetail/PointDetail.java
+++ b/src/main/java/com/backend/backend/domain/pointDetail/PointDetail.java
@@ -35,6 +35,9 @@ public class PointDetail {
     @Column(nullable = false)
     private String  sender;
 
+    @Column(nullable = false)
+    private Long  amount;
+
     @CreatedDate
     private LocalDateTime date;
 
@@ -46,11 +49,14 @@ public class PointDetail {
 
     @Builder
     public PointDetail(Member owner, String recipient, String sender,
-                       PointStatus status, String detail) {
+                       PointStatus status,Long amount, String detail) {
         Assert.hasText(recipient, "수신처가 없습니다");
         Assert.hasText(sender, "발신처가 없습니다");
         if(owner==null){
             throw new NotExistException("기록 소유자가 없습니다");
+        }
+        if(amount==null){
+            throw new NotExistException("포인트 양이 입력되지 않았습니다");
         }
         if(status==null){
             throw new NotExistException("포인트거래가 입력인지 출력인지 알수 없습니다");
@@ -60,6 +66,7 @@ public class PointDetail {
         this.recipient = recipient;
         this.sender = sender;
         this.status = status;
+        this.amount = amount;
         this.detail = detail;
     }
 }

--- a/src/main/java/com/backend/backend/domain/pointDetail/PointStatus.java
+++ b/src/main/java/com/backend/backend/domain/pointDetail/PointStatus.java
@@ -1,5 +1,5 @@
 package com.backend.backend.domain.pointDetail;
 
 public enum PointStatus {
-    CREDIT,TRANSFER
+    DEPOSIT,TRANSFER
 }

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -31,7 +31,7 @@ public class PointService {
                 .owner(member)
                 .recipient(nickname)
                 .sender(sender)
-                .status(PointStatus.CREDIT)
+                .status(PointStatus.DEPOSIT)
                 .amount(amount)
                 .build();
         if(memberPoint==null){

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -20,8 +20,9 @@ public class PointService {
      * @param amount 충전할 포인트 양
      */
     @Transactional
-    public void chargePoint(String nickname, Long amount){
-        Point memberPoint = memberRepository.findMemberByNickname(nickname).getPoint();
+    public void chargePoint(String nickname, String sender, Long amount, String detail){
+        Member member=memberRepository.findMemberByNickname(nickname);
+        Point memberPoint = member.getPoint();
         if(memberPoint==null){
             throw new NotExistException("해당 회원이 존재하지 않습니다");
         }

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -47,12 +47,21 @@ public class PointService {
      * @param amount 인출할 포인트양
      */
     @Transactional
-    public void withdrawPoint(String nickname, Long amount){
-        Point memberPoint = memberRepository.findMemberByNickname(nickname).getPoint();
+    public void withdrawPoint(String nickname, String recipient, Long amount){
+        Member member=memberRepository.findMemberByNickname(nickname);
+        Point memberPoint = member.getPoint();
         if(memberPoint==null){
             throw new NotExistException("해당 회원이 존재하지 않습니다");
         }
+        PointDetail pointDetail = PointDetail.builder()
+                .owner(member)
+                .recipient(recipient)
+                .sender(nickname)
+                .status(PointStatus.DEPOSIT)
+                .amount(amount)
+                .build();
         memberPoint.subPoint(amount);
+        pointDetailRepository.save(pointDetail);
     }
 
     /**

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -72,13 +72,8 @@ public class PointService {
      */
     @Transactional
     public void remittancePoint(String senderNickname,String receiverNickname, Long amount){
-        Point senderPoint = memberRepository.findMemberByNickname(senderNickname).getPoint();
-        Point receiverPoint = memberRepository.findMemberByNickname(receiverNickname).getPoint();
-        if(senderPoint==null||receiverPoint==null){
-            throw new NotExistException("해당 회원이 존재하지 않습니다");
-        }
-        senderPoint.subPoint(amount);
-        receiverPoint.addPoint(amount);
+        chargePoint(receiverNickname,senderNickname,amount);
+        withdrawPoint(senderNickname,receiverNickname,amount);
     }
 
 }

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -24,7 +24,7 @@ public class PointService {
      * @param amount 충전할 포인트 양
      */
     @Transactional
-    public void chargePoint(String nickname, String sender, Long amount, String detail){
+    public void chargePoint(String nickname, String sender, Long amount){
         Member member=memberRepository.findMemberByNickname(nickname);
         Point memberPoint = member.getPoint();
         PointDetail pointDetail = PointDetail.builder()

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -2,8 +2,11 @@ package com.backend.backend.service;
 
 import com.backend.backend.domain.member.Member;
 import com.backend.backend.domain.member.Point;
+import com.backend.backend.domain.pointDetail.PointDetail;
+import com.backend.backend.domain.pointDetail.PointStatus;
 import com.backend.backend.exception.NotExistException;
 import com.backend.backend.repository.memberRepository.MemberRepository;
+import com.backend.backend.repository.pointDetailRepository.PointDetailRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +16,7 @@ import javax.transaction.Transactional;
 @RequiredArgsConstructor
 public class PointService {
     private final MemberRepository memberRepository;
+    private final PointDetailRepository pointDetailRepository;
 
     /**
      * 포인트를 충전하는 메소드
@@ -23,10 +27,18 @@ public class PointService {
     public void chargePoint(String nickname, String sender, Long amount, String detail){
         Member member=memberRepository.findMemberByNickname(nickname);
         Point memberPoint = member.getPoint();
+        PointDetail pointDetail = PointDetail.builder()
+                .owner(member)
+                .recipient(nickname)
+                .sender(sender)
+                .status(PointStatus.CREDIT)
+                .amount(amount)
+                .build();
         if(memberPoint==null){
             throw new NotExistException("해당 회원이 존재하지 않습니다");
         }
         memberPoint.addPoint(amount);
+        pointDetailRepository.save(pointDetail);
     }
 
     /**

--- a/src/main/java/com/backend/backend/service/PointService.java
+++ b/src/main/java/com/backend/backend/service/PointService.java
@@ -21,6 +21,7 @@ public class PointService {
     /**
      * 포인트를 충전하는 메소드
      * @param nickname 충전할 사람
+     * @param sender 돈이 들어 오는 곳
      * @param amount 충전할 포인트 양
      */
     @Transactional
@@ -44,6 +45,7 @@ public class PointService {
     /**
      * 포인트를 인출하는 메소드
      * @param nickname 인출할 사람
+     * @param recipient 인출한 돈을 받는 곳
      * @param amount 인출할 포인트양
      */
     @Transactional

--- a/src/test/java/com/backend/backend/repository/pointDetailRepository/MySqlPointDetailRepositoryTest.java
+++ b/src/test/java/com/backend/backend/repository/pointDetailRepository/MySqlPointDetailRepositoryTest.java
@@ -10,16 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -53,7 +50,7 @@ class MySqlPointDetailRepositoryTest {
                 .owner(member)
                 .recipient("a")
                 .sender("b")
-                .status(PointStatus.CREDIT)
+                .status(PointStatus.DEPOSIT)
                 .amount(10L)
                 .build();
         Long id = pointDetailRepository.save(pointDetail);
@@ -66,7 +63,7 @@ class MySqlPointDetailRepositoryTest {
                 .owner(member)
                 .recipient("a")
                 .sender("b")
-                .status(PointStatus.CREDIT)
+                .status(PointStatus.DEPOSIT)
                 .amount(10L)
                 .build();
         pointDetailRepository.save(pointDetail1);
@@ -74,7 +71,7 @@ class MySqlPointDetailRepositoryTest {
                 .owner(member)
                 .recipient("a")
                 .sender("b")
-                .status(PointStatus.CREDIT)
+                .status(PointStatus.DEPOSIT)
                 .amount(10L)
                 .build();
         pointDetailRepository.save(pointDetail2);

--- a/src/test/java/com/backend/backend/repository/pointDetailRepository/MySqlPointDetailRepositoryTest.java
+++ b/src/test/java/com/backend/backend/repository/pointDetailRepository/MySqlPointDetailRepositoryTest.java
@@ -54,6 +54,7 @@ class MySqlPointDetailRepositoryTest {
                 .recipient("a")
                 .sender("b")
                 .status(PointStatus.CREDIT)
+                .amount(10L)
                 .build();
         Long id = pointDetailRepository.save(pointDetail);
         Assertions.assertThat(pointDetailRepository.findDetailById(id)).isSameAs(pointDetail);
@@ -66,6 +67,7 @@ class MySqlPointDetailRepositoryTest {
                 .recipient("a")
                 .sender("b")
                 .status(PointStatus.CREDIT)
+                .amount(10L)
                 .build();
         pointDetailRepository.save(pointDetail1);
         PointDetail pointDetail2 = PointDetail.builder()
@@ -73,6 +75,7 @@ class MySqlPointDetailRepositoryTest {
                 .recipient("a")
                 .sender("b")
                 .status(PointStatus.CREDIT)
+                .amount(10L)
                 .build();
         pointDetailRepository.save(pointDetail2);
 

--- a/src/test/java/com/backend/backend/service/PointServiceTest.java
+++ b/src/test/java/com/backend/backend/service/PointServiceTest.java
@@ -115,6 +115,9 @@ class PointServiceTest {
 
         Assertions.assertThat(sender.getPoint().getAmount()).isEqualTo(initAmount-remittanceAmount);
         Assertions.assertThat(receiver.getPoint().getAmount()).isEqualTo(remittanceAmount);
+        Assertions.assertThat(pointDetailRepository.findDetailsByMember(receiver).size()).isEqualTo(1);
+        //입금, 출금 하나씩 기록됨
+        Assertions.assertThat(pointDetailRepository.findDetailsByMember(sender).size()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/backend/backend/service/PointServiceTest.java
+++ b/src/test/java/com/backend/backend/service/PointServiceTest.java
@@ -1,8 +1,10 @@
 package com.backend.backend.service;
 
 import com.backend.backend.domain.member.Member;
+import com.backend.backend.domain.pointDetail.PointDetail;
 import com.backend.backend.exception.pointException.PointAmountError;
 import com.backend.backend.repository.memberRepository.MemberRepository;
+import com.backend.backend.repository.pointDetailRepository.PointDetailRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,9 @@ class PointServiceTest {
 
     @Autowired
     private PointService pointService;
+
+    @Autowired
+    private PointDetailRepository pointDetailRepository;
     String memberNickname1="testMember1";
     String memberNickname2="testMember2";
     @BeforeEach
@@ -50,9 +55,10 @@ class PointServiceTest {
         Member member = memberRepository.findMemberByNickname(memberNickname1);
 
         Long amount=50L;
-        pointService.chargePoint(member.getNickname(),amount);
+        pointService.chargePoint(member.getNickname(),"test",amount,"");
 
         Assertions.assertThat(member.getPoint().getAmount()).isEqualTo(amount);
+        Assertions.assertThat(pointDetailRepository.findDetailsByMember(member).size()).isEqualTo(1);
     }
 
     @Test
@@ -61,7 +67,7 @@ class PointServiceTest {
         Long amount=-50L;
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{
-            pointService.chargePoint(member.getNickname(),amount);
+            pointService.chargePoint(member.getNickname(),"test",amount,"");
         });
     }
 
@@ -69,7 +75,7 @@ class PointServiceTest {
     void withdrawPoint() {
         Long initAmount = 86L;
         Member member = memberRepository.findMemberByNickname(memberNickname1);
-        pointService.chargePoint(member.getNickname(),initAmount);
+        pointService.chargePoint(member.getNickname(),"test",initAmount,"");
 
         Long withdrawAmount=48L;
         pointService.withdrawPoint(member.getNickname(),withdrawAmount);
@@ -81,7 +87,7 @@ class PointServiceTest {
     void withdrawPointError() {
         Long initAmount = 86L;
         Member member = memberRepository.findMemberByNickname(memberNickname1);
-        pointService.chargePoint(member.getNickname(),initAmount);
+        pointService.chargePoint(member.getNickname(),"test",initAmount,"");
 
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{
@@ -100,7 +106,7 @@ class PointServiceTest {
         Long initAmount = 86L;
         Member sender = memberRepository.findMemberByNickname(memberNickname1);
         Member receiver = memberRepository.findMemberByNickname(memberNickname2);
-        pointService.chargePoint(sender.getNickname(),initAmount);
+        pointService.chargePoint(sender.getNickname(),"test",initAmount,"");
 
         Long remittanceAmount=48L;
         pointService.remittancePoint(sender.getNickname(),receiver.getNickname(),remittanceAmount);
@@ -114,7 +120,7 @@ class PointServiceTest {
         Long initAmount = 86L;
         Member sender = memberRepository.findMemberByNickname(memberNickname1);
         Member receiver = memberRepository.findMemberByNickname(memberNickname2);
-        pointService.chargePoint(sender.getNickname(),initAmount);
+        pointService.chargePoint(sender.getNickname(),"test",initAmount,"");
 
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{

--- a/src/test/java/com/backend/backend/service/PointServiceTest.java
+++ b/src/test/java/com/backend/backend/service/PointServiceTest.java
@@ -78,10 +78,11 @@ class PointServiceTest {
         pointService.chargePoint(member.getNickname(),"test",initAmount,"");
 
         Long withdrawAmount=48L;
-        pointService.withdrawPoint(member.getNickname(),withdrawAmount);
+        pointService.withdrawPoint(member.getNickname(),"test",withdrawAmount);
 
         Assertions.assertThat(member.getPoint().getAmount()).isEqualTo(initAmount-withdrawAmount);
-        Assertions.assertThat(pointDetailRepository.findDetailsByMember(member).size()).isEqualTo(1);
+        //입금, 출금 하나씩 기록됨
+        Assertions.assertThat(pointDetailRepository.findDetailsByMember(member).size()).isEqualTo(2);
     }
 
     @Test
@@ -93,12 +94,12 @@ class PointServiceTest {
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{
             Long withdrawAmount=-48L;
-            pointService.withdrawPoint(member.getNickname(),withdrawAmount);
+            pointService.withdrawPoint(member.getNickname(),"test",withdrawAmount);
         });
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{
             Long withdrawAmount=90L;
-            pointService.withdrawPoint(member.getNickname(),withdrawAmount);
+            pointService.withdrawPoint(member.getNickname(),"test",withdrawAmount);
         });
     }
 

--- a/src/test/java/com/backend/backend/service/PointServiceTest.java
+++ b/src/test/java/com/backend/backend/service/PointServiceTest.java
@@ -55,7 +55,7 @@ class PointServiceTest {
         Member member = memberRepository.findMemberByNickname(memberNickname1);
 
         Long amount=50L;
-        pointService.chargePoint(member.getNickname(),"test",amount,"");
+        pointService.chargePoint(member.getNickname(),"test",amount);
 
         Assertions.assertThat(member.getPoint().getAmount()).isEqualTo(amount);
         Assertions.assertThat(pointDetailRepository.findDetailsByMember(member).size()).isEqualTo(1);
@@ -67,7 +67,7 @@ class PointServiceTest {
         Long amount=-50L;
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{
-            pointService.chargePoint(member.getNickname(),"test",amount,"");
+            pointService.chargePoint(member.getNickname(),"test",amount);
         });
     }
 
@@ -75,7 +75,7 @@ class PointServiceTest {
     void withdrawPoint() {
         Long initAmount = 86L;
         Member member = memberRepository.findMemberByNickname(memberNickname1);
-        pointService.chargePoint(member.getNickname(),"test",initAmount,"");
+        pointService.chargePoint(member.getNickname(),"test",initAmount);
 
         Long withdrawAmount=48L;
         pointService.withdrawPoint(member.getNickname(),"test",withdrawAmount);
@@ -89,7 +89,7 @@ class PointServiceTest {
     void withdrawPointError() {
         Long initAmount = 86L;
         Member member = memberRepository.findMemberByNickname(memberNickname1);
-        pointService.chargePoint(member.getNickname(),"test",initAmount,"");
+        pointService.chargePoint(member.getNickname(),"test",initAmount);
 
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{
@@ -108,7 +108,7 @@ class PointServiceTest {
         Long initAmount = 86L;
         Member sender = memberRepository.findMemberByNickname(memberNickname1);
         Member receiver = memberRepository.findMemberByNickname(memberNickname2);
-        pointService.chargePoint(sender.getNickname(),"test",initAmount,"");
+        pointService.chargePoint(sender.getNickname(),"test",initAmount);
 
         Long remittanceAmount=48L;
         pointService.remittancePoint(sender.getNickname(),receiver.getNickname(),remittanceAmount);
@@ -122,7 +122,7 @@ class PointServiceTest {
         Long initAmount = 86L;
         Member sender = memberRepository.findMemberByNickname(memberNickname1);
         Member receiver = memberRepository.findMemberByNickname(memberNickname2);
-        pointService.chargePoint(sender.getNickname(),"test",initAmount,"");
+        pointService.chargePoint(sender.getNickname(),"test",initAmount);
 
 
         org.junit.jupiter.api.Assertions.assertThrows(PointAmountError.class,()->{

--- a/src/test/java/com/backend/backend/service/PointServiceTest.java
+++ b/src/test/java/com/backend/backend/service/PointServiceTest.java
@@ -81,6 +81,7 @@ class PointServiceTest {
         pointService.withdrawPoint(member.getNickname(),withdrawAmount);
 
         Assertions.assertThat(member.getPoint().getAmount()).isEqualTo(initAmount-withdrawAmount);
+        Assertions.assertThat(pointDetailRepository.findDetailsByMember(member).size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
- 포인트 거래시 그 기록이 저장되도록 PointService를 수정
- 수정도중 pointDetail 엔티티에 포인트 양을 나타내는 amount가 없어 추가
- pointDetail의 detail의 명칭이 옳지 않다고 생각하여 memo로 수정